### PR TITLE
Metaquery bugfix

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -71,10 +71,10 @@ export default class HeroicDatasource {
 
   /** @ngInject */
   constructor(instanceSettings: datasource.InstanceSettings,
-              private $q,
-              private backendSrv,
-              templateSrv,
-              private uiSegmentSrv) {
+    private $q,
+    private backendSrv,
+    templateSrv,
+    private uiSegmentSrv) {
     this.type = "heroic";
     this.settings = instanceSettings;
 
@@ -102,7 +102,7 @@ export default class HeroicDatasource {
     this.supportAnnotations = true;
     this.supportMetrics = true;
     this.annotationModels = [[{ type: "average", categoryName: "For Each", params: [] }]];
-    this.annotationModels = _.map(this.annotationModels, function(parts: any) {
+    this.annotationModels = _.map(this.annotationModels, function (parts: any) {
       return _.map(parts, queryPart.create);
     });
     this.fakeController = true;
@@ -147,12 +147,12 @@ export default class HeroicDatasource {
       } else {
         target.queryResolution = null;
       }
-      return {query: query, refId: target.refId};
+      return { query: query, refId: target.refId };
     }).filter((queryWrapper) => {
       return queryWrapper !== null && queryWrapper.query !== null && JSON.stringify(queryWrapper.query.filter) !== "[\"true\"]";
     });
 
-    if (!allQueries) {
+    if (!allQueries.length) {
       return this.$q.when({ data: [] });
     }
 
@@ -203,7 +203,7 @@ export default class HeroicDatasource {
   }
 
   public annotationQuery(options) {
-    const queryModel = new HeroicQuery({tags: options.annotation.tags}, this.templateSrv, {});
+    const queryModel = new HeroicQuery({ tags: options.annotation.tags }, this.templateSrv, {});
     const currentFilter = queryModel.buildCurrentFilter(true, false);
 
     const query = {
@@ -245,7 +245,7 @@ export default class HeroicDatasource {
   }
 
   public testDatasource() {
-    return this.doRequest("/status", {}).then(function(data) {
+    return this.doRequest("/status", {}).then(function (data) {
       const service = data.data.service;
 
       return {
@@ -307,7 +307,7 @@ export default class HeroicDatasource {
     return timeObject;
   }
 
-  public convertRawTime(date: string|number, roundUp: boolean): string {
+  public convertRawTime(date: string | number, roundUp: boolean): string {
     if (typeof date === "string") {
       if (date === "now") {
         return "now()";
@@ -333,7 +333,7 @@ export default class HeroicDatasource {
     };
     return this.queryBuilder.queryTagsAndValues(data, "key", this.queryBuilder.lruTag).then(result => {
       return result.map(iresult => {
-        return {value: iresult.key, text: iresult.key};
+        return { value: iresult.key, text: iresult.key };
       });
     });
   }
@@ -346,7 +346,7 @@ export default class HeroicDatasource {
     };
     return this.queryBuilder.queryTagsAndValues(data, "value", this.queryBuilder.lruTagValue).then(result => {
       return result.map(iresult => {
-        return {value: iresult.value, text: iresult.value};
+        return { value: iresult.value, text: iresult.value };
       });
     });
   }
@@ -384,7 +384,7 @@ export default class HeroicDatasource {
     };
     return this.queryBuilder.queryTagsAndValues(data, toGet, this.queryBuilder[cacheKey]).then(result => {
       return result.map(iresult => {
-        return {value: iresult[toGet], text: iresult[toGet]};
+        return { value: iresult[toGet], text: iresult[toGet] };
       });
     });
   }

--- a/src/heroic_series.ts
+++ b/src/heroic_series.ts
@@ -114,6 +114,7 @@ export default class HeroicSeries {
           target: undefined,
           datapoints: [],
           meta: {
+            isHeroicSeries: true,
             scoped: {
               tags: { text: '' },
               fullTags: { text: '' },
@@ -147,7 +148,7 @@ export default class HeroicSeries {
       const scoped = this.buildScoped(series, commonCounts, this.resultData.result.length);
       const target: string = this.templateSrv.replaceWithText(this.alias || defaultAlias, scoped);
       const datapoints: Datapoint[] = series.values.map(this._convertData);
-      const meta = { scoped, errors, limits };
+      const meta = { scoped, errors, limits, isHeroicSeries: true };
       return { refId, target, datapoints, meta };
     });
   }
@@ -187,10 +188,10 @@ export default class HeroicSeries {
           tags: _.uniq(
             _.flatten(
               tagsCol
-                .filter(function(t) {
+                .filter(function (t) {
                   return series.tags[t];
                 })
-                .map(function(t) {
+                .map(function (t) {
                   return series.tags[t].split(',');
                 })
             )

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -26,6 +26,7 @@ import { HeroicValidator } from './validator';
 import { QueryParser } from './query_parser';
 import queryPart from './query_part';
 import { DataSeries, RenderedQuery, Target, Tag, Category, CategoryItem, QueryPart, Part } from './types';
+import HeroicSeries from './heroic_series';
 
 export class HeroicQueryCtrl extends QueryCtrl {
   static templateUrl = 'partials/query.editor.html';
@@ -84,7 +85,7 @@ export class HeroicQueryCtrl extends QueryCtrl {
     const categories = queryPart.getCategories();
     this.selectMenu = _.reduce(
       categories,
-      function(memo, cat, key) {
+      function (memo, cat, key) {
         const menu = {
           text: key,
           submenu: cat.map(item => {
@@ -220,6 +221,7 @@ export class HeroicQueryCtrl extends QueryCtrl {
   }
 
   public onDataReceived(dataList: DataSeries[]) {
+    dataList = dataList.filter(series => series.meta !== undefined && series.meta.isHeroicSeries);
     this.dataList = dataList;
 
     if (this.target.resultFormat === 'time_series') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,22 +63,25 @@ export interface Tag {
 
 export type Datapoint = [number, number];
 
+export interface HeroicMetaData {
+  isHeroicSeries: boolean;
+  scoped: {
+    tags: {
+      text: string;
+    };
+    fullTags: {
+      text: string;
+    };
+  };
+  errors: any[];
+  limits: string[];
+}
+
 export interface DataSeries {
   refId: string;
   datapoints: Datapoint[];
   target: string;
-  meta: {
-    scoped: {
-      tags: {
-        text: string;
-      };
-      fullTags: {
-        text: string;
-      };
-    };
-    errors: any[];
-    limits: string[];
-  };
+  meta: HeroicMetaData;
 }
 
 export interface HeroicBatchResult {


### PR DESCRIPTION
Fixes a bug in QueryController where MetaQueries will fail on refresh.

This bug is related to the Grafana 6.5 upgrade. The QueryController error handling UI expects to receive Heroic time series with meta properties present. As of Grafana 6.5, MetaQueries do not set meta properties, thus throwing the error in the UI.

Fixes in this PR:
- Fixes a found bug in datasource where a check for empty queries will always evaluate to false.
- Updates QueryController by setting an identifier on the meta property to only perform UI error handling on Heroic time series.