### PR TITLE
Add support for variables in filter aggregations

### DIFF
--- a/src/heroic_query.test.ts
+++ b/src/heroic_query.test.ts
@@ -83,11 +83,11 @@ describe('HeroicQuery', () => {
 
       beforeEach(() => {
         ctx.target.tags = [{ key: "key", operator: "=", value: "value" }];
-        ctx.templateSrv.replace = jest.fn(query => query.startsWith('$') ? someGlobalVars[query] || null : query)
-      })
+        ctx.templateSrv.replace = jest.fn(query => query.startsWith('$') ? someGlobalVars[query] || null : query);
+      });
 
       it('...should set the correct default value', () => {
-        ctx.target.select = [[{ type: "abovek", params: ['5'], categoryName: "Filters" }]]
+        ctx.target.select = [[{ type: "abovek", params: ['5'], categoryName: "Filters" }]];
         const queryModel = new HeroicQuery(ctx.target, ctx.templateSrv, ctx.scopedVars);
         const query = queryModel.render();
 
@@ -98,7 +98,7 @@ describe('HeroicQuery', () => {
       });
 
       it('...should set the correct value', () => {
-        ctx.target.select = [[{ type: 'belowk', params: ['100'], categoryName: "Filters" }]]
+        ctx.target.select = [[{ type: 'belowk', params: ['100'], categoryName: "Filters" }]];
         const queryModel = new HeroicQuery(ctx.target, ctx.templateSrv, ctx.scopedVars);
         const query = queryModel.render();
 
@@ -109,11 +109,11 @@ describe('HeroicQuery', () => {
       });
 
       it('...should set the correct value when given a valid variable', () => {
-        ctx.target.select = [[{ type: 'topk', params: ['$var'], categoryName: "Filters" }]]
+        ctx.target.select = [[{ type: 'topk', params: ['$var'], categoryName: "Filters" }]];
         const queryModel = new HeroicQuery(ctx.target, ctx.templateSrv, ctx.scopedVars);
         const query = queryModel.render();
 
-        expect(ctx.templateSrv.replace).toHaveBeenCalledWith('$var')
+        expect(ctx.templateSrv.replace).toHaveBeenCalledWith('$var');
         expect(query.aggregators.length).toEqual(1);
         expect(query.aggregators[0].type).toEqual('topk');
         expect(query.aggregators[0].k).toEqual(100);
@@ -121,17 +121,17 @@ describe('HeroicQuery', () => {
       });
 
       it('...should set the return null when given an invalid variable', () => {
-        ctx.target.select = [[{ type: 'topk', params: ['badVarWithNoDollarSignPrefix'], categoryName: "Filters" }]]
+        ctx.target.select = [[{ type: 'topk', params: ['badVarWithNoDollarSignPrefix'], categoryName: "Filters" }]];
         const queryModel = new HeroicQuery(ctx.target, ctx.templateSrv, ctx.scopedVars);
         const query = queryModel.render();
 
-        expect(ctx.templateSrv.replace).toHaveBeenCalledWith('badVarWithNoDollarSignPrefix')
+        expect(ctx.templateSrv.replace).toHaveBeenCalledWith('badVarWithNoDollarSignPrefix');
         expect(query.aggregators.length).toEqual(1);
         expect(query.aggregators[0].type).toEqual('topk');
         expect(query.aggregators[0].k).toBeNull();
         expect(query.aggregators[0].of.type).toEqual('empty');
       });
 
-    })
+    });
   });
 });

--- a/src/heroic_query.ts
+++ b/src/heroic_query.ts
@@ -195,7 +195,11 @@ export default class HeroicQuery {
 
     const aggregatorsRendered = this.selectModels.map(modelParts => {
       return modelParts.map(modelPart => {
-        return modelPart.def.renderer(modelPart, undefined, currentIntervalValue);
+        return modelPart.def.categoryName === "Filters"
+          ? modelPart.def.renderer({
+            params: [this.templateSrv.replace(modelPart.params[0])]
+          }, undefined, currentIntervalValue)
+          : modelPart.def.renderer(modelPart, undefined, currentIntervalValue);
       });
     });
 


### PR DESCRIPTION
Simple check to see if aggregation is a filter and if so calls the template service to replace the param. If the param is a user defined variable prefixed with a dollar sign, it will be replaced. Otherwise, it will return null as usual.

This PR resolves [#99](https://github.com/spotify/spotify-heroic-datasource/issues/99)