### PR TITLE
Display $key tag with other suggested tags

### DIFF
--- a/src/validator.ts
+++ b/src/validator.ts
@@ -63,7 +63,7 @@ export class HeroicValidator {
     return badTags;
   }
 
-  public isMissingNamespace() {
+  public isMissingKey() {
     const { tags } = this.target;
     for (const tag of tags) {
       const { key } = tag;
@@ -85,8 +85,8 @@ export class HeroicValidator {
       warnings.push(`Aggregating <strong>${message}</strong> can cause misleading results.`);
     }
 
-    if (this.isMissingNamespace()) {
-      warnings.push('Missing $key filter. It is good practice to always filter tags by namespace.');
+    if (this.isMissingKey()) {
+      warnings.push('No $key filter specified. Omitting a $key filter may produce unintended results.');
     }
 
     const collapsedKeys = this.findUnsafeCollapses(data);

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -63,6 +63,15 @@ export class HeroicValidator {
     return badTags;
   }
 
+  public isMissingNamespace() {
+    const { tags } = this.target;
+    for (const tag of tags) {
+      const { key } = tag;
+      if (key === '$key') { return false; }
+    }
+    return true;
+  }
+
   public checkForWarnings(data: DataSeries[]): string {
     const warnings = [];
     const badTags = this.findUnsafeAggregations(data);
@@ -76,6 +85,10 @@ export class HeroicValidator {
       warnings.push(`Aggregating <strong>${message}</strong> can cause misleading results.`);
     }
 
+    if (this.isMissingNamespace()) {
+      warnings.push('Missing $key filter. It is good practice to always filter tags by namespace.');
+    }
+
     const collapsedKeys = this.findUnsafeCollapses(data);
     if (collapsedKeys.length > 0) {
       let message;
@@ -84,7 +97,7 @@ export class HeroicValidator {
       } else {
         message =
           `Aggregating several of keys <strong>'${collapsedKeys.slice(0, collapsedKeys.length - 1).join("', '")}\' or \'${
-            collapsedKeys[collapsedKeys.length - 1]
+          collapsedKeys[collapsedKeys.length - 1]
           }'</strong> ` + 'is probably not what you want. For each key, add a filter or group by aggregation.';
       }
       warnings.push(message);


### PR DESCRIPTION
Adds $key tag to suggested tag dropdown. If a $key has already been set, it will not appear in subsequent suggestions. A warning message will now alert the user if it has not been set.

#53 