### PR TITLE
add context to queries

### DIFF
--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -47,6 +47,7 @@ describe('HeroicDataSource', () => {
     };
 
     ctx.ds = new HeroicDatasource(ctx.instanceSettings, ctx.$q, ctx.backendSrv, ctx.templateSrv, ctx.uiSegmentSrv);
+    ctx.ds.meta = { id: 'spotify-heroic-datasource' };
   });
 
   describe('When querying Heroic with one target', () => {
@@ -96,6 +97,8 @@ describe('HeroicDataSource', () => {
           ],
         },
       ],
+      dashboardId: '222',
+      panelId: '333',
       interval: '1m',
       rangeRaw: { from: 'now-6h', to: 'now' },
       scopedVars: {
@@ -110,6 +113,10 @@ describe('HeroicDataSource', () => {
       aggregators: [{ type: 'group', of: ['site'], each: [{ type: 'sum', sampling: { unit: 'seconds', value: '1m' } }] }],
       features: ['com.spotify.heroic.distributed_aggregations'],
       range: timeRange,
+      clientContext: {
+        dashboardId: '222',
+        panelId: '333'
+      }
     };
 
     const queryResult = {
@@ -161,6 +168,10 @@ describe('HeroicDataSource', () => {
       const res = ctx.backendSrv.datasourceRequest.mock.calls[0][0];
 
       expect(res.inspect.type).toBe('heroic');
+      expect(res.headers).toEqual({
+        'Content-Type': 'application/json;charset=UTF-8',
+        'X-Client-Id': 'spotify-heroic-datasource'
+      });
       expect(res.method).toBe('POST');
       expect(res.url).toBe(urlExpected);
     });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -48,6 +48,7 @@ export default class HeroicDatasource {
   public tagAggregationChecks: any;
   public tagCollapseChecks: any[];
   public suggestionRules: any;
+  public meta: any;
 
   /** @ngInject */
   constructor(instanceSettings: datasource.InstanceSettings,
@@ -101,6 +102,10 @@ export default class HeroicDatasource {
     const scopedVars = options.scopedVars;
     const targets: Target[] = _.cloneDeep(options.targets);
     const targetsByRef: Record<string, Target> = {};
+    const clientContext = {
+      dashboardId: options.dashboardId,
+      panelId: options.panelId,
+    };
     targets.forEach(target => {
       targetsByRef[target.refId] = target;
     });
@@ -111,8 +116,7 @@ export default class HeroicDatasource {
       }
 
       scopedVars.interval = scopedVars.__interval;
-
-      queryModel = new HeroicQuery(target, this.templateSrv, scopedVars);
+      queryModel = new HeroicQuery(target, this.templateSrv, scopedVars, clientContext);
       const query = queryModel.render();
       if (query.aggregators.length) {
         const samplers: string[] = query.aggregators.filter(a => a.each !== undefined)
@@ -247,7 +251,10 @@ export default class HeroicDatasource {
     return this.backendSrv.datasourceRequest(options);
   }
   public doRequest(path, options) {
-    const headers = { "Content-Type": "application/json;charset=UTF-8" };
+    const headers = {
+      "Content-Type": "application/json;charset=UTF-8",
+      "X-Client-Id": this.meta.id
+    };
     return this.doRequestWithHeaders(path, options, headers);
   }
 

--- a/src/heroic_query.ts
+++ b/src/heroic_query.ts
@@ -24,17 +24,17 @@ import queryPart from './query_part';
 import { RenderedQuery, Filter, Target, TagOperators, Tag, QueryPart, Part } from './types';
 
 export default class HeroicQuery {
-  public target: any;
   public selectModels: any[];
   public groupByParts: any;
-  public templateSrv: any;
-  public scopedVars: any;
+  public panelCtrl: any;
+  public clientContext: any;
 
   /** @ngInject */
-  constructor(target: any, templateSrv?, scopedVars?) {
+  constructor(public target: any, public templateSrv?, public scopedVars?, public context?) {
     this.target = target;
     this.templateSrv = templateSrv;
     this.scopedVars = scopedVars;
+    this.clientContext = context || {};
 
     target.resultFormat = target.resultFormat || 'time_series';
     target.orderByTime = target.orderByTime || 'ASC';
@@ -184,6 +184,7 @@ export default class HeroicQuery {
 
   public render(): RenderedQuery {
     let target: Target = this.target;
+    const clientContext = this.clientContext;
     const currentFilter = this.buildCurrentFilter(true, true);
     let currentIntervalUnit = null;
     let currentIntervalValue = null;
@@ -217,6 +218,7 @@ export default class HeroicQuery {
       aggregators: aggregators,
       features: features,
       range: '$timeFilter',
+      clientContext
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export interface RenderedQuery {
   aggregators: any[];
   features: string[];
   range: string;
+  clientContext: ClientContext;
 }
 
 export type Filter = (string | string[])[];
@@ -35,6 +36,7 @@ export interface Part {
 export interface Target {
   alias: string;
   globalAggregation?: boolean;
+  clientContext: ClientContext;
 
   query: string;
   queryRaw: string;
@@ -135,4 +137,9 @@ export declare namespace datasource {
     tagAggregationChecks: string[];
     suggestionRules: any[];
   }
+}
+
+interface ClientContext {
+  dashboardId: string;
+  panelId: string;
 }


### PR DESCRIPTION
This PR resolves #63 and makes the following changes:

1. Adds a default 'X-Client-Id" header to all batch requests.
2. Adds a "clientContext" field with dashboard and panel ids.