### PR TITLE
Add warning caching to datasource

### DIFF
--- a/src/heroic_series.ts
+++ b/src/heroic_series.ts
@@ -20,6 +20,7 @@
 
 import TableModel from 'app/core/table_model';
 import _ from 'lodash';
+import WarningsCache from './warnings_cache';
 import { HeroicBatchData, DataSeries, Datapoint } from './types';
 
 export default class HeroicSeries {
@@ -102,10 +103,11 @@ export default class HeroicSeries {
     series.values = withAfter;
   }
 
-  public getTimeSeries(refId: string): DataSeries[] {
+  public getTimeSeries({ refId, dashboardId, panelId }): DataSeries[] {
     const min = this.getMinFromResults(this.resultData.result);
     const max = this.getMaxFromResults(this.resultData.result);
     const { limits, errors } = this.resultData;
+    const warningsKey = WarningsCache.createKey({ refId, dashboardId, panelId });
 
     if (this.resultData.result.length === 0) {
       return [
@@ -115,6 +117,7 @@ export default class HeroicSeries {
           datapoints: [],
           meta: {
             isHeroicSeries: true,
+            warningsKey,
             scoped: {
               tags: { text: '' },
               fullTags: { text: '' },
@@ -148,7 +151,7 @@ export default class HeroicSeries {
       const scoped = this.buildScoped(series, commonCounts, this.resultData.result.length);
       const target: string = this.templateSrv.replaceWithText(this.alias || defaultAlias, scoped);
       const datapoints: Datapoint[] = series.values.map(this._convertData);
-      const meta = { scoped, errors, limits, isHeroicSeries: true };
+      const meta = { scoped, errors, limits, warningsKey, isHeroicSeries: true };
       return { refId, target, datapoints, meta };
     });
   }

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -1,10 +1,10 @@
 <query-editor-row query-ctrl="ctrl" can-collapse="true" has-text-edit-mode="true">
-	<div class="gf-form" ng-if="ctrl.warningMessage != ''">
-		<label class="gf-form-label text-error">
-			<a ng-click="ctrl.clearWarnings()">
+	<div class="gf-form gf-form--grow" ng-repeat="warning in ctrl.warnings">
+		<label class="gf-form-label gf-form-label--grow text-error">
+			<a ng-click="ctrl.clearWarning(warning)">
 				<i class="fa fa-close"></i>
 			</a>
-			<ng-bind-html ng-bind-html="ctrl.warningMessage">
+			<ng-bind-html ng-bind-html="warning">
 			</ng-bind-html>
 		</label>
 	</div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,7 @@ export interface Target {
   alias: string;
   globalAggregation?: boolean;
   clientContext: ClientContext;
-
+  warningsKey: string;
   query: string;
   queryRaw: string;
   rawQuery: boolean;
@@ -67,6 +67,7 @@ export type Datapoint = [number, number];
 
 export interface HeroicMetaData {
   isHeroicSeries: boolean;
+  warningsKey: string;
   scoped: {
     tags: {
       text: string;

--- a/src/warnings_cache.ts
+++ b/src/warnings_cache.ts
@@ -1,0 +1,65 @@
+declare namespace WarningsCache {
+  type key = string;
+  type warning = string;
+  type CacheMap = Map<key, warning[]>;
+
+  interface Options {
+    dashboardId: string;
+    panelId: number;
+    refId: string;
+  }
+}
+
+export default class WarningsCache {
+  private cache: WarningsCache.CacheMap;
+
+  constructor() {
+    this.cache = new Map();
+  }
+
+  static createKey({ dashboardId, panelId, refId }: WarningsCache.Options) {
+    return `${dashboardId}::${panelId}::${refId}`;
+  }
+
+  public hasCache(key: WarningsCache.key) {
+    return this.cache.has(key);
+  }
+
+  public clear(): void {
+    this.cache.clear();
+  }
+
+  public createCache(key: WarningsCache.key) {
+    if (this.cache.has(key)) { return key; }
+    this.cache.set(key, []);
+  }
+
+  public removeCache(key: WarningsCache.key) {
+    if (!this.cache.has(key)) { return; }
+    this.cache.delete(key);
+  }
+
+  public getWarnings(key: WarningsCache.key) {
+    return this.cache.get(key);
+  }
+
+  public addWarning(key: WarningsCache.key, warning: WarningsCache.warning) {
+    if (!this.cache.has(key)) { return; }
+    const warnings = this.cache.get(key);
+    if (warnings.includes(warning)) { return; }
+    this.cache.set(key, warnings.concat(warning));
+  }
+
+  public removeWarning(key: WarningsCache.key, warning: WarningsCache.warning) {
+    if (this.cache.has(key)) {
+      const warnings = this.getWarnings(key).filter(_warning => _warning !== warning);
+      this.cache.set(key, warnings);
+    }
+  }
+
+  public removeAllWarnings(key: WarningsCache.key) {
+    if (!this.cache.has(key)) { return; }
+    this.cache.set(key, []);
+  }
+
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,11 @@
     "experimentalDecorators": true,
     "noImplicitAny": false,
     "skipLibCheck": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "lib": [
+      "dom",
+      "es7"
+    ]
   },
   "include": [
     "dist/**/*.ts"


### PR DESCRIPTION
This PR contains the following changes:
- Adds caching of error warnings to datasource (partially addresses #79)
- Fixes issue where the query editor obscures warnings (#114)
- Removes event name deprecation warning
- updates test files

Currently, "inline" error warnings are lost between dashboard <--> panel navigations. Heroic (not Grafana) warnings are only generated after data is received in the query panel. When users navigate away from the editor to the dashboard and back to the editor - without requerying - these warnings are lost and can lead to confusion. 

Warnings will now persist in the query editor across panel/dashboard navigations until they are manually dismissed or the user requeries Heroic. This PR does not address dashboard level warnings (aka "dogear" warnings) generated by Grafana and may be addressed in a separate PR.