### PR TITLE
Format warnings

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -27,7 +27,6 @@ import queryPart from "./query_part";
 import TimeRange from "./time_range";
 import { MetadataClient } from "./metadata_client";
 import WarningsCache from './warnings_cache';
-import { HeroicValidator } from './validator';
 import {
   Target,
   DataSeries,
@@ -35,6 +34,8 @@ import {
   HeroicBatchData,
   datasource
 } from "./types";
+//@ts-ignore
+import { PanelEvents } from '@grafana/data';
 
 export default class HeroicDatasource {
   public type: string;
@@ -191,13 +192,15 @@ export default class HeroicDatasource {
         });
 
         _.forEach(output, target => {
-          if (!this.warningsCache.hasCache(target.meta.warningsKey)) {
-            this.warningsCache.createCache(target.meta.warningsKey);
+          const { warningsKey } = target.meta;
+          if (!this.warningsCache.hasCache(warningsKey)) {
+            this.warningsCache.createCache(warningsKey);
           } else {
-            this.warningsCache.removeAllWarnings(target.meta.warningsKey);
+            this.warningsCache.removeAllWarnings(warningsKey);
           }
           target.meta.errors.forEach(error => {
-            this.warningsCache.addWarning(target.meta.warningsKey, error.error);
+            const msg = WarningsCache.formatWarning(error);
+            this.warningsCache.addWarning(warningsKey, msg);
           });
         });
 

--- a/src/warnings_cache.ts
+++ b/src/warnings_cache.ts
@@ -21,6 +21,15 @@ export default class WarningsCache {
     return `${dashboardId}::${panelId}::${refId}`;
   }
 
+  static formatWarning(warning) {
+    let { error: msg, type } = warning;
+    if (msg.length > 100) {
+      msg = msg.slice(0, 100).concat('...[See Query Inspector to view full error details]');
+    }
+    type = type[0].toUpperCase().concat(type.slice(1));
+    return `[${type} Error]: ${msg}`;
+  }
+
   public hasCache(key: WarningsCache.key) {
     return this.cache.has(key);
   }


### PR DESCRIPTION
Tag along PR for updated warnings.

- Format messages to first 100 chars to avoid overflowing container. Directs user to Query Inspector to view full details.
- Adds a flag + check to for toggling alert suggestion popups when in panel mode. **Disables** alerts by default.
- `QueryCtrl` does not override `refresh` method. Adds option to `QueryCtrl.ctrlRefresh` to call it manually.